### PR TITLE
Fix the compatibility with newer doctrine/orm versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": "~8.0",
 		"consistence-community/consistence": "~2.1",
 		"doctrine/annotations": "~1.7",
-		"doctrine/orm": "^2.6.3"
+		"doctrine/orm": "^2.10.0"
 	},
 	"require-dev": {
 		"consistence-community/coding-standard": "3.11.1",

--- a/src/Enum/EnumPostLoadEntityListener.php
+++ b/src/Enum/EnumPostLoadEntityListener.php
@@ -100,7 +100,7 @@ class EnumPostLoadEntityListener
 		$enum = $enumClassName::get(($enumValue instanceof Enum) ? $enumValue->getValue() : $enumValue);
 		$metadata->setFieldValue($entity, $fieldName, $enum);
 		$entityManager->getUnitOfWork()->setOriginalEntityProperty(
-			spl_object_hash($entity),
+			spl_object_id($entity),
 			$fieldName,
 			$enum
 		);


### PR DESCRIPTION
Between versions 2.9.6 and 2.10.0 of doctrine/orm the way of generating the object identifiers has been changed (https://github.com/doctrine/orm/commit/84ad007de39bc0947be838c8efcf1455513cbdca). So we need to change it the same way in the EnumPostLoadEntityListener to keep the compatibility with newer doctrine/orm versions.

Fixes https://github.com/consistence-community/consistence-doctrine/issues/5