### PR TITLE
Update to doctrine/annotations:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "~7.4 || ~8.0",
 		"consistence-community/consistence": "~2.1",
-		"doctrine/annotations": "~1.7",
+		"doctrine/annotations": "~1.7 || ^2.0",
 		"doctrine/orm": "^2.10.0"
 	},
 	"require-dev": {
@@ -35,6 +35,9 @@
 		"classmap": [ "tests" ]
 	},
 	"config": {
-		"bin-dir": "bin"
+		"bin-dir": "bin",
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/tests/Enum/data/FooParentEntity.php
+++ b/tests/Enum/data/FooParentEntity.php
@@ -7,7 +7,7 @@ namespace Consistence\Doctrine\Enum;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ORM\MappedSuperClass
+ * @ORM\MappedSuperclass
  */
 class FooParentEntity
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,9 +11,7 @@ use Doctrine\DBAL\Types\Type as DoctrineType;
 
 error_reporting(E_ALL);
 
-$loader = require __DIR__ . '/../vendor/autoload.php';
-
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+require __DIR__ . '/../vendor/autoload.php';
 
 DoctrineType::addType(FloatEnumType::NAME, FloatEnumType::class);
 DoctrineType::addType(IntegerEnumType::NAME, IntegerEnumType::class);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,6 @@ use Consistence\Doctrine\Enum\Type\BooleanEnumType;
 use Consistence\Doctrine\Enum\Type\FloatEnumType;
 use Consistence\Doctrine\Enum\Type\IntegerEnumType;
 use Consistence\Doctrine\Enum\Type\StringEnumType;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\DBAL\Types\Type as DoctrineType;
 
 error_reporting(E_ALL);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,15 +2,19 @@
 
 declare(strict_types = 1);
 
+use Consistence\Doctrine\Enum\EnumAnnotation;
 use Consistence\Doctrine\Enum\Type\BooleanEnumType;
 use Consistence\Doctrine\Enum\Type\FloatEnumType;
 use Consistence\Doctrine\Enum\Type\IntegerEnumType;
 use Consistence\Doctrine\Enum\Type\StringEnumType;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\DBAL\Types\Type as DoctrineType;
 
 error_reporting(E_ALL);
 
 require __DIR__ . '/../vendor/autoload.php';
+
+AnnotationRegistry::loadAnnotationClass(EnumAnnotation::class);
 
 DoctrineType::addType(FloatEnumType::NAME, FloatEnumType::class);
 DoctrineType::addType(IntegerEnumType::NAME, IntegerEnumType::class);


### PR DESCRIPTION
This allows `doctrine/annotations:^2.0` to be used with this project. 